### PR TITLE
fix: oauth2-proxy healthcheck and Caddy dependency

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -151,12 +151,6 @@ services:
       resources:
         limits:
           memory: 128m
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:4180/ping"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     logging:
       driver: json-file
       options:
@@ -180,7 +174,7 @@ services:
       frontend:
         condition: service_healthy
       oauth2-proxy:
-        condition: service_healthy
+        condition: service_started
     networks:
       - app_network
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Remove broken oauth2-proxy healthcheck (`wget` not available in distroless v7.14.2 image)
- Change Caddy's dependency on oauth2-proxy from `service_healthy` to `service_started` so the full stack boots even before Google OAuth credentials are configured

## Context
Discovered during deployment that oauth2-proxy v7.14.2 ships as a distroless image with no `wget` or `curl`, making the `CMD wget` healthcheck always fail. This prevented Caddy from starting since it depended on `service_healthy`.

## Test plan
- [x] Verified all 5 containers start and run on the droplet
- [x] `/healthz` returns 200 (no auth)
- [x] `/mcp/tools` returns 401 without bearer, 200 with bearer
- [x] `/` redirects to Google OAuth sign-in (forward_auth working)
- [x] TLS certificate provisioned by Caddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated service startup configuration to improve deployment efficiency by simplifying service readiness monitoring
  * Optimized initialization dependencies to enhance application startup performance and streamline service sequencing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->