### PR TITLE
feat: extend SpotifyClient with playlist and info methods (Phase A)

### DIFF
--- a/docs/playlist_and_track_info_plan.md
+++ b/docs/playlist_and_track_info_plan.md
@@ -1,0 +1,157 @@
+# Plan: Spotify Playlist Management & Track Info MCP Tools
+
+## Context
+
+ChatGPT can currently only *read* listening history and search Spotify. The user wants ChatGPT to also:
+- Get detailed info about tracks, artists, and albums
+- Create, modify, and delete playlists
+
+This requires extending the SpotifyClient (currently GET-only) to support POST/PUT/DELETE, adding Pydantic models for playlist/album responses, adding 9 new MCP tools, updating OAuth scopes, and updating the ChatGPT OpenAPI schema.
+
+**Existing users must re-authorize** via `/auth/login` to grant new playlist scopes. Write tools will return a clear error if scopes are missing.
+
+## New MCP Tools (9 total)
+
+| Tool | Method | Description |
+|------|--------|-------------|
+| `spotify.get_track` | GET | Track details (artists, album, duration, popularity) |
+| `spotify.get_artist` | GET | Artist details (genres, popularity, followers) |
+| `spotify.get_album` | GET | Album details with track listing |
+| `spotify.list_playlists` | GET | User's playlists (name, id, track count) |
+| `spotify.get_playlist` | GET | Playlist details with tracks |
+| `spotify.create_playlist` | POST | Create new playlist |
+| `spotify.add_tracks` | POST | Add tracks to a playlist (by track IDs) |
+| `spotify.remove_tracks` | DELETE | Remove tracks from a playlist |
+| `spotify.update_playlist` | PUT | Update playlist name/description/visibility |
+
+---
+
+## Phase A — PR #1: SpotifyClient Foundation + Models
+
+Extend the shared Spotify client to support POST/PUT/DELETE and add all new Pydantic models. No new MCP tools yet — just the building blocks.
+
+### Files to modify:
+
+**`services/shared/src/shared/spotify/constants.py`** — Add URL constants:
+- `ALBUMS_URL = f"{SPOTIFY_API_BASE}/albums"`
+- `USER_PLAYLISTS_URL = f"{SPOTIFY_API_BASE}/me/playlists"`
+- `PLAYLIST_URL = f"{SPOTIFY_API_BASE}/playlists"`
+
+**`services/shared/src/shared/spotify/models.py`** — Add ~10 Pydantic models:
+- `SpotifyTrackSimplified` — track without album field (for album track listings)
+- `SpotifyAlbumTracksPage` — paging object for album tracks
+- `SpotifyAlbumFull(SpotifyAlbumSimplified)` — full album with tracks, genres, popularity, label
+- `SpotifyPlaylistOwner` — owner object (id, display_name)
+- `SpotifyPlaylistTrackItem` — playlist track entry (track + added_at)
+- `SpotifyPlaylistTracks` — paging object for playlist tracks
+- `SpotifyPlaylist` — full playlist (name, description, public, owner, tracks)
+- `SpotifyPlaylistSimplified` — simplified playlist for list endpoints
+- `UserPlaylistsResponse` — paginated response from `GET /me/playlists`
+- `SpotifySnapshotResponse` — response from add/remove tracks (`snapshot_id`)
+
+**`services/shared/src/shared/spotify/client.py`** — Extend client:
+- Add `json_body: dict[str, Any] | None = None` param to `_request()`, pass as `json=json_body` to `httpx.request()`
+- Add 9 new public methods: `get_track`, `get_artist`, `get_album`, `get_user_playlists`, `get_playlist`, `create_playlist`, `add_tracks_to_playlist`, `remove_tracks_from_playlist`, `update_playlist_details`
+
+### Tests:
+- **`services/api/tests/test_spotify/test_client.py`** (extend) — ~10 tests using `respx` mocks for each new client method
+
+### Verification:
+- `make lint` + `make typecheck` pass
+- `pytest services/api/tests/test_spotify/` passes
+
+---
+
+## Phase B — PR #2: Read-Only MCP Tools (info + playlist read)
+
+Add 5 read-only MCP tools that use the new client methods. Update OAuth scopes.
+
+### Files to modify:
+
+**`services/api/src/app/constants.py`** — Add `playlist-read-private` to OAuth scopes:
+```python
+SPOTIFY_SCOPES = (
+    "user-read-recently-played user-top-read user-read-email user-read-private "
+    "playlist-read-private"
+)
+```
+
+**`services/api/src/app/mcp/tools/spotify_tools.py`** — Add 3 info tools to existing `SpotifyToolHandlers`:
+- `spotify.get_track(user_id, track_id)` — returns curated dict (id, name, artists, album, duration, popularity)
+- `spotify.get_artist(user_id, artist_id)` — returns curated dict (id, name, genres, popularity, followers)
+- `spotify.get_album(user_id, album_id)` — returns curated dict (id, name, tracks listing, artists, release_date)
+
+**`services/api/src/app/mcp/tools/playlist_tools.py`** — New file with `PlaylistToolHandlers`:
+- `spotify.list_playlists(user_id, limit)` — list user's playlists
+- `spotify.get_playlist(user_id, playlist_id)` — get playlist details with tracks
+- Own `_get_client()` helper (same pattern as `SpotifyToolHandlers`)
+
+**`services/api/src/app/mcp/tools/__init__.py`** — Add `import app.mcp.tools.playlist_tools`
+
+**`docs/chatgpt-openapi.json` + `docs/chatgpt-openapi.yaml`** — Add 5 read tool names + new params (`track_id`, `artist_id`, `album_id`, `playlist_id`)
+
+**`docs/chatgpt-gpt-setup.md`** — Add new tools to GPT instructions
+
+**`CLAUDE.md`** — Update MCP tools list
+
+### Tests:
+- **`services/api/tests/test_mcp/test_router.py`** — update expected tool count
+- **`services/api/tests/test_mcp/test_playlist_tools.py`** (new) — ~6 tests for read tools via `/mcp/call`
+
+### Verification:
+- `make lint` + `make typecheck` pass
+- `pytest services/api/tests/` passes
+- Deploy, test via curl: `spotify.get_track`, `spotify.list_playlists`, `spotify.get_playlist`
+
+---
+
+## Phase C — PR #3: Playlist Write Tools
+
+Add 4 mutating MCP tools with scope validation.
+
+### Files to modify:
+
+**`services/api/src/app/constants.py`** — Add write scopes:
+```python
+SPOTIFY_SCOPES = (
+    "user-read-recently-played user-top-read user-read-email user-read-private "
+    "playlist-read-private playlist-modify-public playlist-modify-private"
+)
+```
+
+**`services/api/src/app/mcp/tools/playlist_tools.py`** — Add to `PlaylistToolHandlers`:
+- `_check_scopes(user_id, session, required_scopes)` — queries `SpotifyToken.scope`, returns error message if missing
+- `spotify.create_playlist(user_id, name, description?, public?)` — POST /me/playlists
+- `spotify.add_tracks(user_id, playlist_id, track_ids)` — converts IDs to `spotify:track:{id}` URIs, caps at 100
+- `spotify.remove_tracks(user_id, playlist_id, track_ids)` — DELETE with URIs, caps at 100
+- `spotify.update_playlist(user_id, playlist_id, name?, description?, public?)` — PUT details
+
+All write handlers call `_check_scopes()` first and return clear "re-authorize via /auth/login" error if missing.
+
+**`docs/chatgpt-openapi.json` + `docs/chatgpt-openapi.yaml`** — Add 4 write tool names + params (`name`, `description`, `public`, `track_ids`)
+
+**`docs/chatgpt-gpt-setup.md`** — Add write tools + examples
+
+**`CLAUDE.md`** — Update MCP tools list
+
+### Tests:
+- **`services/api/tests/test_mcp/test_playlist_tools.py`** (extend) — ~8 tests: write tools via `/mcp/call`, scope validation failures, track count limits, empty list errors
+
+### Verification:
+- `make lint` + `make typecheck` pass
+- `pytest services/api/tests/` passes
+- Deploy, re-authorize user via `/auth/login`
+- Test full flow via curl: create playlist → add tracks → remove tracks → update → verify in Spotify app
+- Update ChatGPT Custom GPT action with final OpenAPI schema
+- Test in ChatGPT: "Create a playlist of my top 10 tracks from the last month"
+
+---
+
+## Key Design Decisions
+
+1. **`_request()` extension**: Add optional `json_body` param (not breaking — existing callers unaffected)
+2. **`create_playlist` uses `POST /me/playlists`** (not the deprecated `/users/{id}/playlists`)
+3. **Track ID → URI conversion**: Tool handlers convert `track_ids` to `spotify:track:{id}` URIs so ChatGPT only needs to pass IDs
+4. **Scope validation on writes only**: Read tools work without extra scopes (public playlists always visible). Write tools check `SpotifyToken.scope` and return MCP error if missing
+5. **Info tools in `spotify_tools.py`**, playlist tools in new `playlist_tools.py`**: separates read-only info lookups from playlist CRUD
+6. **Curated MCP responses**: Return focused dicts, not raw Spotify API responses, to keep outputs concise for ChatGPT

--- a/services/shared/src/shared/spotify/constants.py
+++ b/services/shared/src/shared/spotify/constants.py
@@ -15,6 +15,9 @@ AUDIO_FEATURES_URL = f"{SPOTIFY_API_BASE}/audio-features"
 TOP_ARTISTS_URL = f"{SPOTIFY_API_BASE}/me/top/artists"
 TOP_TRACKS_URL = f"{SPOTIFY_API_BASE}/me/top/tracks"
 SEARCH_URL = f"{SPOTIFY_API_BASE}/search"
+ALBUMS_URL = f"{SPOTIFY_API_BASE}/albums"
+USER_PLAYLISTS_URL = f"{SPOTIFY_API_BASE}/me/playlists"
+PLAYLIST_URL = f"{SPOTIFY_API_BASE}/playlists"
 
 # Retry defaults
 DEFAULT_MAX_RETRIES = 3

--- a/services/shared/src/shared/spotify/models.py
+++ b/services/shared/src/shared/spotify/models.py
@@ -243,3 +243,129 @@ class SpotifySearchResponse(BaseModel):
     tracks: SpotifySearchTracks | None = None
     artists: SpotifySearchArtists | None = None
     albums: SpotifySearchAlbums | None = None
+
+
+# ---------------------------------------------------------------------------
+# Albums (full)
+# ---------------------------------------------------------------------------
+
+
+class SpotifyTrackSimplified(BaseModel):
+    """Simplified track object (no album field, used in album track listings)."""
+
+    id: str | None = None
+    name: str
+    uri: str | None = None
+    duration_ms: int | None = None
+    explicit: bool | None = None
+    track_number: int | None = None
+    disc_number: int | None = None
+    artists: list[SpotifyArtistSimplified] = Field(default_factory=list)
+    external_urls: dict[str, str] = Field(default_factory=dict)
+    href: str | None = None
+
+
+class SpotifyAlbumTracksPage(BaseModel):
+    """Paging object for tracks within an album."""
+
+    items: list[SpotifyTrackSimplified] = Field(default_factory=list)
+    total: int | None = None
+    limit: int | None = None
+    offset: int | None = None
+    next: str | None = None
+
+
+class SpotifyAlbumFull(SpotifyAlbumSimplified):
+    """Full album object from GET /albums/{id}."""
+
+    genres: list[str] = Field(default_factory=list)
+    popularity: int | None = None
+    label: str | None = None
+    total_tracks: int | None = None
+    tracks: SpotifyAlbumTracksPage | None = None
+    artists: list[SpotifyArtistSimplified] = Field(default_factory=list)
+    copyrights: list[dict[str, str]] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Playlists
+# ---------------------------------------------------------------------------
+
+
+class SpotifyPlaylistOwner(BaseModel):
+    """Playlist owner object."""
+
+    id: str | None = None
+    display_name: str | None = None
+    uri: str | None = None
+    external_urls: dict[str, str] = Field(default_factory=dict)
+
+
+class SpotifyPlaylistTrackItem(BaseModel):
+    """Single item within a playlist's tracks array."""
+
+    track: SpotifyTrack | None = None
+    added_at: str | None = None
+    added_by: SpotifyPlaylistOwner | None = None
+
+
+class SpotifyPlaylistTracks(BaseModel):
+    """Paging object for tracks within a playlist."""
+
+    items: list[SpotifyPlaylistTrackItem] = Field(default_factory=list)
+    total: int | None = None
+    limit: int | None = None
+    offset: int | None = None
+    next: str | None = None
+    href: str | None = None
+
+
+class SpotifyPlaylist(BaseModel):
+    """Full playlist object from GET /playlists/{id} or POST /me/playlists."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    public: bool | None = None
+    collaborative: bool | None = None
+    owner: SpotifyPlaylistOwner | None = None
+    images: list[SpotifyImage] = Field(default_factory=list)
+    tracks: SpotifyPlaylistTracks | None = None
+    snapshot_id: str | None = None
+    uri: str | None = None
+    href: str | None = None
+    external_urls: dict[str, str] = Field(default_factory=dict)
+
+
+class SpotifyPlaylistSimplified(BaseModel):
+    """Simplified playlist from list endpoints (tracks has only total)."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    public: bool | None = None
+    collaborative: bool | None = None
+    owner: SpotifyPlaylistOwner | None = None
+    images: list[SpotifyImage] = Field(default_factory=list)
+    tracks: dict[str, int] | None = None
+    snapshot_id: str | None = None
+    uri: str | None = None
+    href: str | None = None
+    external_urls: dict[str, str] = Field(default_factory=dict)
+
+
+class UserPlaylistsResponse(BaseModel):
+    """Response from GET /me/playlists."""
+
+    items: list[SpotifyPlaylistSimplified] = Field(default_factory=list)
+    total: int | None = None
+    limit: int | None = None
+    offset: int | None = None
+    next: str | None = None
+    href: str | None = None
+
+
+class SpotifySnapshotResponse(BaseModel):
+    """Response from add/remove tracks operations."""
+
+    snapshot_id: str


### PR DESCRIPTION
## Summary
Phase A of the playlist management feature (see `docs/playlist_and_track_info_plan.md` for full 3-phase plan).

- Extend `SpotifyClient._request()` with `json_body` parameter for POST/PUT/DELETE support
- Add 9 new client methods: `get_track`, `get_artist`, `get_album`, `get_user_playlists`, `get_playlist`, `create_playlist`, `add_tracks_to_playlist`, `remove_tracks_from_playlist`, `update_playlist_details`
- Add 10 Pydantic models for playlist and full album API responses (`SpotifyPlaylist`, `SpotifyAlbumFull`, `UserPlaylistsResponse`, etc.)
- Add 3 URL constants (`ALBUMS_URL`, `USER_PLAYLISTS_URL`, `PLAYLIST_URL`)
- Add 12 new tests for all new client methods (42 total spotify tests, 187 total API tests)

No new MCP tools yet — this PR builds the foundation. Phases B and C will add the MCP tools.

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy` passes (strict)
- [x] 42 spotify tests pass (12 new)
- [x] 187 total API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capabilities to retrieve track, artist, and album details
  * Added playlist management support including creation, retrieval, and track modifications

* **Documentation**
  * Added planning document outlining Spotify integration roadmap

* **Tests**
  * Expanded test coverage for playlist and track operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->