### PR TITLE
feat: read-only MCP tools for track/artist/album info and playlists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,11 @@ When ZIP imports lack Spotify URIs:
 ### Spotify Live Tools
 - `spotify.get_top(entity, time_range, limit, user_id)` - Spotify's native "top" API
 - `spotify.search(q, type, limit, user_id)` - Search tracks/artists/albums
+- `spotify.get_track(track_id, user_id)` - Detailed track info (artists, album, duration, popularity)
+- `spotify.get_artist(artist_id, user_id)` - Detailed artist info (genres, popularity, followers)
+- `spotify.get_album(album_id, user_id)` - Album details with full track listing
+- `spotify.list_playlists(limit, user_id)` - List user's Spotify playlists
+- `spotify.get_playlist(playlist_id, user_id)` - Playlist details with tracks
 
 ### Ops Tools
 - `ops.list_users()` - List all registered users

--- a/docs/chatgpt-gpt-setup.md
+++ b/docs/chatgpt-gpt-setup.md
@@ -58,6 +58,11 @@ AVAILABLE TOOLS (via callTool action):
 - history.coverage — Data completeness and collection sources
 - spotify.get_top — Spotify's native top artists/tracks (live, not historical)
 - spotify.search — Search Spotify catalog
+- spotify.get_track — Get detailed track info by ID (pass track_id)
+- spotify.get_artist — Get detailed artist info by ID (pass artist_id)
+- spotify.get_album — Get album details and track listing by ID (pass album_id)
+- spotify.list_playlists — List the user's Spotify playlists
+- spotify.get_playlist — Get playlist details and tracks by ID (pass playlist_id)
 - ops.sync_status — Check data collection status
 - ops.latest_job_runs — Recent sync job history
 - ops.latest_import_jobs — Recent data import status

--- a/docs/chatgpt-openapi.json
+++ b/docs/chatgpt-openapi.json
@@ -37,6 +37,11 @@
                       "history.coverage",
                       "spotify.get_top",
                       "spotify.search",
+                      "spotify.get_track",
+                      "spotify.get_artist",
+                      "spotify.get_album",
+                      "spotify.list_playlists",
+                      "spotify.get_playlist",
                       "ops.sync_status",
                       "ops.latest_job_runs",
                       "ops.latest_import_jobs"
@@ -72,6 +77,22 @@
                     "type": "string",
                     "description": "For spotify.search only: type of search. Default 'track'.",
                     "enum": ["track", "artist", "album"]
+                  },
+                  "track_id": {
+                    "type": "string",
+                    "description": "Spotify track ID. For spotify.get_track."
+                  },
+                  "artist_id": {
+                    "type": "string",
+                    "description": "Spotify artist ID. For spotify.get_artist."
+                  },
+                  "album_id": {
+                    "type": "string",
+                    "description": "Spotify album ID. For spotify.get_album."
+                  },
+                  "playlist_id": {
+                    "type": "string",
+                    "description": "Spotify playlist ID. For spotify.get_playlist."
                   }
                 }
               }

--- a/docs/chatgpt-openapi.yaml
+++ b/docs/chatgpt-openapi.yaml
@@ -39,6 +39,11 @@ paths:
                     - history.coverage
                     - spotify.get_top
                     - spotify.search
+                    - spotify.get_track
+                    - spotify.get_artist
+                    - spotify.get_album
+                    - spotify.list_playlists
+                    - spotify.get_playlist
                     - ops.sync_status
                     - ops.latest_job_runs
                     - ops.latest_import_jobs
@@ -72,6 +77,18 @@ paths:
                   type: string
                   description: "For spotify.search only: type of search. Default 'track'."
                   enum: [track, artist, album]
+                track_id:
+                  type: string
+                  description: "Spotify track ID. For spotify.get_track."
+                artist_id:
+                  type: string
+                  description: "Spotify artist ID. For spotify.get_artist."
+                album_id:
+                  type: string
+                  description: "Spotify album ID. For spotify.get_album."
+                playlist_id:
+                  type: string
+                  description: "Spotify playlist ID. For spotify.get_playlist."
       responses:
         "200":
           description: Tool result

--- a/services/api/src/app/constants.py
+++ b/services/api/src/app/constants.py
@@ -7,7 +7,7 @@ SPOTIFY_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_ME_URL = "https://api.spotify.com/v1/me"
 
 # Spotify OAuth scopes required by this application
-SPOTIFY_SCOPES = "user-read-recently-played user-top-read user-read-email user-read-private"
+SPOTIFY_SCOPES = "user-read-recently-played user-top-read user-read-email user-read-private playlist-read-private"
 
 # Default configuration values
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://localhost:8000/auth/callback"

--- a/services/api/src/app/mcp/tools/__init__.py
+++ b/services/api/src/app/mcp/tools/__init__.py
@@ -2,4 +2,5 @@
 
 import app.mcp.tools.history_tools as history_tools  # noqa: F401
 import app.mcp.tools.ops_tools as ops_tools  # noqa: F401
+import app.mcp.tools.playlist_tools as playlist_tools  # noqa: F401
 import app.mcp.tools.spotify_tools as spotify_tools  # noqa: F401

--- a/services/api/src/app/mcp/tools/playlist_tools.py
+++ b/services/api/src/app/mcp/tools/playlist_tools.py
@@ -1,0 +1,100 @@
+"""MCP tool handlers for Spotify playlist read operations — class-based."""
+
+import logging
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.tokens import TokenManager
+from app.mcp.registry import registry
+from app.mcp.schemas import MCPToolParam
+from app.settings import get_settings
+from shared.spotify.client import SpotifyClient
+
+logger = logging.getLogger(__name__)
+
+_USER_PARAM = MCPToolParam(name="user_id", type="int", description="User ID (must have active OAuth)")
+
+
+class PlaylistToolHandlers:
+    """Registers and handles playlist-related MCP tools."""
+
+    def __init__(self) -> None:
+        self._register()
+
+    def _register(self) -> None:
+        registry.register(
+            name="spotify.list_playlists",
+            description="List the user's Spotify playlists (name, id, track count, public/private)",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="limit", type="int", description="Max playlists (1-50)", required=False, default=50),
+            ],
+        )(self.list_playlists)
+
+        registry.register(
+            name="spotify.get_playlist",
+            description="Get playlist details including track listing by playlist ID",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="playlist_id", type="str", description="Spotify playlist ID"),
+            ],
+        )(self.get_playlist)
+
+    async def _get_client(self, user_id: int, session: AsyncSession) -> SpotifyClient:
+        """Create a SpotifyClient with token management for the given user."""
+        settings = get_settings()
+        token_mgr = TokenManager(settings)
+        access_token = await token_mgr.get_valid_token(user_id, session)
+
+        async def _on_token_expired() -> str:
+            return await token_mgr.refresh_access_token(user_id, session)
+
+        return SpotifyClient(access_token, on_token_expired=_on_token_expired)
+
+    async def list_playlists(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        client = await self._get_client(args["user_id"], session)
+        limit = max(1, min(args.get("limit", 50), 50))
+        resp = await client.get_user_playlists(limit=limit)
+        return [
+            {
+                "id": p.id,
+                "name": p.name,
+                "public": p.public,
+                "tracks_total": p.tracks.get("total") if p.tracks else None,
+                "owner": p.owner.display_name if p.owner else None,
+            }
+            for p in resp.items
+        ]
+
+    async def get_playlist(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        client = await self._get_client(args["user_id"], session)
+        pl = await client.get_playlist(args["playlist_id"])
+        tracks = []
+        if pl.tracks:
+            for item in pl.tracks.items:
+                if item.track:
+                    tracks.append(
+                        {
+                            "id": item.track.id,
+                            "name": item.track.name,
+                            "artists": [{"id": a.id, "name": a.name} for a in item.track.artists],
+                            "added_at": item.added_at,
+                        }
+                    )
+        return {
+            "id": pl.id,
+            "name": pl.name,
+            "description": pl.description,
+            "public": pl.public,
+            "owner": pl.owner.display_name if pl.owner else None,
+            "tracks_total": pl.tracks.total if pl.tracks else 0,
+            "tracks": tracks,
+            "snapshot_id": pl.snapshot_id,
+            "external_urls": pl.external_urls,
+        }
+
+
+_instance = PlaylistToolHandlers()

--- a/services/api/tests/test_mcp/test_playlist_tools.py
+++ b/services/api/tests/test_mcp/test_playlist_tools.py
@@ -1,0 +1,358 @@
+"""Tests for spotify info + playlist read tools invoked through the MCP dispatcher."""
+
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+from app.dependencies import db_manager
+from app.main import app
+from app.settings import AppSettings, get_settings
+from shared.db.base import Base
+from shared.db.models.user import User
+from shared.spotify.models import (
+    SpotifyAlbumFull,
+    SpotifyAlbumSimplified,
+    SpotifyAlbumTracksPage,
+    SpotifyArtistFull,
+    SpotifyArtistSimplified,
+    SpotifyImage,
+    SpotifyPlaylist,
+    SpotifyPlaylistOwner,
+    SpotifyPlaylistSimplified,
+    SpotifyPlaylistTrackItem,
+    SpotifyPlaylistTracks,
+    SpotifyTrack,
+    SpotifyTrackSimplified,
+    UserPlaylistsResponse,
+)
+
+TEST_FERNET_KEY = Fernet.generate_key().decode()
+
+
+def _test_settings() -> AppSettings:
+    return AppSettings(
+        SPOTIFY_CLIENT_ID="test",
+        SPOTIFY_CLIENT_SECRET="test",
+        TOKEN_ENCRYPTION_KEY=TEST_FERNET_KEY,
+    )
+
+
+@pytest.fixture
+async def async_engine() -> AsyncGenerator[AsyncEngine]:
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+def override_deps(async_engine: AsyncEngine) -> Generator[None]:
+    factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _override() -> AsyncGenerator[AsyncSession]:
+        async with factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[db_manager.dependency] = _override
+    app.dependency_overrides[get_settings] = _test_settings
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(override_deps: None) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+async def seeded_user(async_engine: AsyncEngine) -> int:
+    factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        user = User(spotify_user_id="pluser", display_name="Playlist User")
+        session.add(user)
+        await session.flush()
+        uid = user.id
+        await session.commit()
+    return uid
+
+
+# ---------------------------------------------------------------------------
+# spotify.get_track
+# ---------------------------------------------------------------------------
+
+
+def test_get_track(client: TestClient, seeded_user: int) -> None:
+    mock_track = SpotifyTrack(
+        id="t1",
+        name="Test Track",
+        duration_ms=240000,
+        popularity=72,
+        explicit=False,
+        artists=[SpotifyArtistSimplified(id="a1", name="Artist One")],
+        album=SpotifyAlbumSimplified(id="al1", name="Album One"),
+        external_urls={"spotify": "https://open.spotify.com/track/t1"},
+    )
+
+    with patch(
+        "app.mcp.tools.spotify_tools.SpotifyToolHandlers._get_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_track = AsyncMock(return_value=mock_track)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            "/mcp/call",
+            json={"tool": "spotify.get_track", "user_id": seeded_user, "track_id": "t1"},
+        )
+        data = resp.json()
+        assert data["success"] is True
+        assert data["result"]["id"] == "t1"
+        assert data["result"]["name"] == "Test Track"
+        assert data["result"]["duration_ms"] == 240000
+        assert data["result"]["popularity"] == 72
+        assert data["result"]["artists"][0]["name"] == "Artist One"
+        assert data["result"]["album"]["name"] == "Album One"
+
+
+# ---------------------------------------------------------------------------
+# spotify.get_artist
+# ---------------------------------------------------------------------------
+
+
+def test_get_artist(client: TestClient, seeded_user: int) -> None:
+    mock_artist = SpotifyArtistFull(
+        id="a1",
+        name="Artist One",
+        genres=["indie rock", "alternative"],
+        popularity=85,
+        followers={"total": 500000},
+        images=[SpotifyImage(url="https://img.spotify.com/a1.jpg", height=640, width=640)],
+        external_urls={"spotify": "https://open.spotify.com/artist/a1"},
+    )
+
+    with patch(
+        "app.mcp.tools.spotify_tools.SpotifyToolHandlers._get_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_artist = AsyncMock(return_value=mock_artist)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            "/mcp/call",
+            json={"tool": "spotify.get_artist", "user_id": seeded_user, "artist_id": "a1"},
+        )
+        data = resp.json()
+        assert data["success"] is True
+        assert data["result"]["id"] == "a1"
+        assert data["result"]["name"] == "Artist One"
+        assert data["result"]["genres"] == ["indie rock", "alternative"]
+        assert data["result"]["popularity"] == 85
+        assert data["result"]["followers"] == {"total": 500000}
+        assert len(data["result"]["images"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# spotify.get_album
+# ---------------------------------------------------------------------------
+
+
+def test_get_album(client: TestClient, seeded_user: int) -> None:
+    mock_album = SpotifyAlbumFull(
+        id="al1",
+        name="Test Album",
+        album_type="album",
+        release_date="2025-06-15",
+        total_tracks=10,
+        artists=[SpotifyArtistSimplified(id="a1", name="Artist One")],
+        genres=["rock"],
+        popularity=60,
+        label="Test Records",
+        tracks=SpotifyAlbumTracksPage(
+            items=[
+                SpotifyTrackSimplified(
+                    id="t1",
+                    name="Track 1",
+                    track_number=1,
+                    duration_ms=180000,
+                    artists=[SpotifyArtistSimplified(id="a1", name="Artist One")],
+                ),
+                SpotifyTrackSimplified(
+                    id="t2",
+                    name="Track 2",
+                    track_number=2,
+                    duration_ms=210000,
+                    artists=[SpotifyArtistSimplified(id="a1", name="Artist One")],
+                ),
+            ],
+            total=10,
+        ),
+        images=[SpotifyImage(url="https://img.spotify.com/al1.jpg")],
+        external_urls={"spotify": "https://open.spotify.com/album/al1"},
+    )
+
+    with patch(
+        "app.mcp.tools.spotify_tools.SpotifyToolHandlers._get_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_album = AsyncMock(return_value=mock_album)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            "/mcp/call",
+            json={"tool": "spotify.get_album", "user_id": seeded_user, "album_id": "al1"},
+        )
+        data = resp.json()
+        assert data["success"] is True
+        assert data["result"]["id"] == "al1"
+        assert data["result"]["name"] == "Test Album"
+        assert data["result"]["total_tracks"] == 10
+        assert data["result"]["label"] == "Test Records"
+        assert len(data["result"]["tracks"]) == 2
+        assert data["result"]["tracks"][0]["name"] == "Track 1"
+        assert data["result"]["tracks"][0]["track_number"] == 1
+
+
+# ---------------------------------------------------------------------------
+# spotify.list_playlists
+# ---------------------------------------------------------------------------
+
+
+def test_list_playlists(client: TestClient, seeded_user: int) -> None:
+    mock_response = UserPlaylistsResponse(
+        items=[
+            SpotifyPlaylistSimplified(
+                id="pl1",
+                name="My Playlist",
+                public=True,
+                tracks={"total": 42},
+                owner=SpotifyPlaylistOwner(id="pluser", display_name="Playlist User"),
+            ),
+            SpotifyPlaylistSimplified(
+                id="pl2",
+                name="Private Jams",
+                public=False,
+                tracks={"total": 10},
+                owner=SpotifyPlaylistOwner(id="pluser", display_name="Playlist User"),
+            ),
+        ],
+        total=2,
+    )
+
+    with patch(
+        "app.mcp.tools.playlist_tools.PlaylistToolHandlers._get_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_user_playlists = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            "/mcp/call",
+            json={"tool": "spotify.list_playlists", "user_id": seeded_user},
+        )
+        data = resp.json()
+        assert data["success"] is True
+        assert len(data["result"]) == 2
+        assert data["result"][0]["id"] == "pl1"
+        assert data["result"][0]["name"] == "My Playlist"
+        assert data["result"][0]["public"] is True
+        assert data["result"][0]["tracks_total"] == 42
+        assert data["result"][1]["id"] == "pl2"
+        assert data["result"][1]["public"] is False
+
+
+# ---------------------------------------------------------------------------
+# spotify.get_playlist
+# ---------------------------------------------------------------------------
+
+
+def test_get_playlist(client: TestClient, seeded_user: int) -> None:
+    mock_playlist = SpotifyPlaylist(
+        id="pl1",
+        name="My Playlist",
+        description="A great playlist",
+        public=True,
+        owner=SpotifyPlaylistOwner(id="pluser", display_name="Playlist User"),
+        snapshot_id="snap123",
+        external_urls={"spotify": "https://open.spotify.com/playlist/pl1"},
+        tracks=SpotifyPlaylistTracks(
+            items=[
+                SpotifyPlaylistTrackItem(
+                    track=SpotifyTrack(
+                        id="t1",
+                        name="Track 1",
+                        artists=[SpotifyArtistSimplified(id="a1", name="Artist One")],
+                    ),
+                    added_at="2025-01-15T10:00:00Z",
+                ),
+                SpotifyPlaylistTrackItem(
+                    track=SpotifyTrack(
+                        id="t2",
+                        name="Track 2",
+                        artists=[SpotifyArtistSimplified(id="a2", name="Artist Two")],
+                    ),
+                    added_at="2025-01-16T12:00:00Z",
+                ),
+            ],
+            total=2,
+        ),
+    )
+
+    with patch(
+        "app.mcp.tools.playlist_tools.PlaylistToolHandlers._get_client",
+        new_callable=AsyncMock,
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_playlist = AsyncMock(return_value=mock_playlist)
+        mock_get_client.return_value = mock_client
+
+        resp = client.post(
+            "/mcp/call",
+            json={"tool": "spotify.get_playlist", "user_id": seeded_user, "playlist_id": "pl1"},
+        )
+        data = resp.json()
+        assert data["success"] is True
+        assert data["result"]["id"] == "pl1"
+        assert data["result"]["name"] == "My Playlist"
+        assert data["result"]["description"] == "A great playlist"
+        assert data["result"]["public"] is True
+        assert data["result"]["owner"] == "Playlist User"
+        assert data["result"]["tracks_total"] == 2
+        assert len(data["result"]["tracks"]) == 2
+        assert data["result"]["tracks"][0]["id"] == "t1"
+        assert data["result"]["tracks"][0]["artists"][0]["name"] == "Artist One"
+        assert data["result"]["snapshot_id"] == "snap123"
+
+
+# ---------------------------------------------------------------------------
+# Tool registration check
+# ---------------------------------------------------------------------------
+
+
+def test_new_tools_registered(client: TestClient) -> None:
+    """All 5 new read tools appear in the tool catalog."""
+    resp = client.get("/mcp/tools")
+    names = {t["name"] for t in resp.json()}
+    expected = {
+        "spotify.get_track",
+        "spotify.get_artist",
+        "spotify.get_album",
+        "spotify.list_playlists",
+        "spotify.get_playlist",
+    }
+    assert expected.issubset(names), f"Missing tools: {expected - names}"

--- a/services/api/tests/test_mcp/test_router.py
+++ b/services/api/tests/test_mcp/test_router.py
@@ -99,7 +99,7 @@ def test_list_tools(client: TestClient) -> None:
     assert resp.status_code == 200
     tools = resp.json()
     assert isinstance(tools, list)
-    assert len(tools) >= 12  # 6 history + 2 spotify + 4 ops
+    assert len(tools) >= 17  # 6 history + 7 spotify + 4 ops
     names = {t["name"] for t in tools}
     assert "history.taste_summary" in names
     assert "ops.sync_status" in names


### PR DESCRIPTION
## Summary
- Add 5 new read-only MCP tools: `spotify.get_track`, `spotify.get_artist`, `spotify.get_album`, `spotify.list_playlists`, `spotify.get_playlist`
- Add `playlist-read-private` to OAuth scopes
- Create `playlist_tools.py` with `PlaylistToolHandlers` class (2 tools)
- Extend `SpotifyToolHandlers` with 3 info tools (get_track, get_artist, get_album)
- Update ChatGPT OpenAPI schemas (JSON + YAML) with 5 new tool names and 4 new parameters
- Update GPT setup docs and CLAUDE.md with new tool listings
- 6 new tests (193 total API tests), all passing

This is **Phase B** of the playlist & track info plan. Phase A (SpotifyClient foundation) was merged in PR #16. Phase C (playlist write tools) will follow.

## Test plan
- [x] All 6 new MCP tool tests pass (mock-based, testing through `/mcp/call` dispatcher)
- [x] Tool registration test verifies all 5 new tools appear in catalog
- [x] Full API test suite passes (193 tests)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean (85 source files)
- [ ] Manual verification after deploy: test info tools and playlist read via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new Spotify tools: retrieve track, artist, and album details by ID; list user playlists; and fetch detailed playlist information with track listings.
  * Updated OAuth permissions to enable private playlist access.

* **Documentation**
  * Updated API documentation to reflect new Spotify capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->