### PR TITLE
feat: playlist write MCP tools with scope validation (Phase C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,10 @@ When ZIP imports lack Spotify URIs:
 - `spotify.get_album(album_id, user_id)` - Album details with full track listing
 - `spotify.list_playlists(limit, user_id)` - List user's Spotify playlists
 - `spotify.get_playlist(playlist_id, user_id)` - Playlist details with tracks
+- `spotify.create_playlist(name, description, public, user_id)` - Create new playlist
+- `spotify.add_tracks(playlist_id, track_ids, user_id)` - Add tracks to playlist (max 100)
+- `spotify.remove_tracks(playlist_id, track_ids, user_id)` - Remove tracks from playlist (max 100)
+- `spotify.update_playlist(playlist_id, name, description, public, user_id)` - Update playlist details
 
 ### Ops Tools
 - `ops.list_users()` - List all registered users

--- a/docs/chatgpt-gpt-setup.md
+++ b/docs/chatgpt-gpt-setup.md
@@ -63,6 +63,10 @@ AVAILABLE TOOLS (via callTool action):
 - spotify.get_album — Get album details and track listing by ID (pass album_id)
 - spotify.list_playlists — List the user's Spotify playlists
 - spotify.get_playlist — Get playlist details and tracks by ID (pass playlist_id)
+- spotify.create_playlist — Create a new playlist (pass name, optional description, public)
+- spotify.add_tracks — Add tracks to a playlist (pass playlist_id, track_ids list, max 100)
+- spotify.remove_tracks — Remove tracks from a playlist (pass playlist_id, track_ids list, max 100)
+- spotify.update_playlist — Update playlist name/description/visibility (pass playlist_id)
 - ops.sync_status — Check data collection status
 - ops.latest_job_runs — Recent sync job history
 - ops.latest_import_jobs — Recent data import status

--- a/docs/chatgpt-openapi.json
+++ b/docs/chatgpt-openapi.json
@@ -42,6 +42,10 @@
                       "spotify.get_album",
                       "spotify.list_playlists",
                       "spotify.get_playlist",
+                      "spotify.create_playlist",
+                      "spotify.add_tracks",
+                      "spotify.remove_tracks",
+                      "spotify.update_playlist",
                       "ops.sync_status",
                       "ops.latest_job_runs",
                       "ops.latest_import_jobs"
@@ -92,7 +96,24 @@
                   },
                   "playlist_id": {
                     "type": "string",
-                    "description": "Spotify playlist ID. For spotify.get_playlist."
+                    "description": "Spotify playlist ID. For playlist tools."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Playlist name. For spotify.create_playlist and spotify.update_playlist."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Playlist description. For spotify.create_playlist and spotify.update_playlist."
+                  },
+                  "public": {
+                    "type": "boolean",
+                    "description": "Whether the playlist is public. For spotify.create_playlist and spotify.update_playlist."
+                  },
+                  "track_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of Spotify track IDs. For spotify.add_tracks and spotify.remove_tracks (max 100)."
                   }
                 }
               }

--- a/docs/chatgpt-openapi.yaml
+++ b/docs/chatgpt-openapi.yaml
@@ -44,6 +44,10 @@ paths:
                     - spotify.get_album
                     - spotify.list_playlists
                     - spotify.get_playlist
+                    - spotify.create_playlist
+                    - spotify.add_tracks
+                    - spotify.remove_tracks
+                    - spotify.update_playlist
                     - ops.sync_status
                     - ops.latest_job_runs
                     - ops.latest_import_jobs
@@ -88,7 +92,21 @@ paths:
                   description: "Spotify album ID. For spotify.get_album."
                 playlist_id:
                   type: string
-                  description: "Spotify playlist ID. For spotify.get_playlist."
+                  description: "Spotify playlist ID. For playlist tools."
+                name:
+                  type: string
+                  description: "Playlist name. For spotify.create_playlist and spotify.update_playlist."
+                description:
+                  type: string
+                  description: "Playlist description. For spotify.create_playlist and spotify.update_playlist."
+                public:
+                  type: boolean
+                  description: "Whether the playlist is public. For spotify.create_playlist and spotify.update_playlist."
+                track_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: "List of Spotify track IDs. For spotify.add_tracks and spotify.remove_tracks (max 100)."
       responses:
         "200":
           description: Tool result

--- a/services/api/src/app/constants.py
+++ b/services/api/src/app/constants.py
@@ -7,7 +7,10 @@ SPOTIFY_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_ME_URL = "https://api.spotify.com/v1/me"
 
 # Spotify OAuth scopes required by this application
-SPOTIFY_SCOPES = "user-read-recently-played user-top-read user-read-email user-read-private playlist-read-private"
+SPOTIFY_SCOPES = (
+    "user-read-recently-played user-top-read user-read-email user-read-private "
+    "playlist-read-private playlist-modify-public playlist-modify-private"
+)
 
 # Default configuration values
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://localhost:8000/auth/callback"

--- a/services/api/src/app/mcp/router.py
+++ b/services/api/src/app/mcp/router.py
@@ -52,6 +52,9 @@ class MCPRouter:
         try:
             result = await registry.invoke(request.tool, request.arguments, session)
             return MCPCallResponse(tool=request.tool, success=True, result=result)
+        except ValueError as exc:
+            logger.warning("MCP tool %s validation error: %s", request.tool, exc)
+            return MCPCallResponse(tool=request.tool, success=False, error=str(exc))
         except Exception as exc:
             logger.exception("MCP tool %s failed", request.tool)
             error_type = type(exc).__name__

--- a/services/api/src/app/mcp/tools/playlist_tools.py
+++ b/services/api/src/app/mcp/tools/playlist_tools.py
@@ -1,19 +1,23 @@
-"""MCP tool handlers for Spotify playlist read operations — class-based."""
+"""MCP tool handlers for Spotify playlist operations — class-based."""
 
 import logging
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.tokens import TokenManager
 from app.mcp.registry import registry
 from app.mcp.schemas import MCPToolParam
 from app.settings import get_settings
+from shared.db.models.user import SpotifyToken
 from shared.spotify.client import SpotifyClient
 
 logger = logging.getLogger(__name__)
 
 _USER_PARAM = MCPToolParam(name="user_id", type="int", description="User ID (must have active OAuth)")
+
+_PLAYLIST_WRITE_SCOPES = {"playlist-modify-public", "playlist-modify-private"}
 
 
 class PlaylistToolHandlers:
@@ -43,6 +47,61 @@ class PlaylistToolHandlers:
             ],
         )(self.get_playlist)
 
+        registry.register(
+            name="spotify.create_playlist",
+            description="Create a new Spotify playlist for the user",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="name", type="str", description="Playlist name"),
+                MCPToolParam(
+                    name="description", type="str", description="Playlist description", required=False, default=""
+                ),
+                MCPToolParam(
+                    name="public",
+                    type="bool",
+                    description="Whether the playlist is public",
+                    required=False,
+                    default=True,
+                ),
+            ],
+        )(self.create_playlist)
+
+        registry.register(
+            name="spotify.add_tracks",
+            description="Add tracks to a playlist (max 100 per call). Pass Spotify track IDs.",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="playlist_id", type="str", description="Spotify playlist ID"),
+                MCPToolParam(name="track_ids", type="list[str]", description="List of Spotify track IDs to add"),
+            ],
+        )(self.add_tracks)
+
+        registry.register(
+            name="spotify.remove_tracks",
+            description="Remove tracks from a playlist (max 100 per call). Pass Spotify track IDs.",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="playlist_id", type="str", description="Spotify playlist ID"),
+                MCPToolParam(name="track_ids", type="list[str]", description="List of Spotify track IDs to remove"),
+            ],
+        )(self.remove_tracks)
+
+        registry.register(
+            name="spotify.update_playlist",
+            description="Update a playlist's name, description, or visibility",
+            category="spotify",
+            parameters=[
+                _USER_PARAM,
+                MCPToolParam(name="playlist_id", type="str", description="Spotify playlist ID"),
+                MCPToolParam(name="name", type="str", description="New playlist name", required=False),
+                MCPToolParam(name="description", type="str", description="New playlist description", required=False),
+                MCPToolParam(name="public", type="bool", description="Set public/private", required=False),
+            ],
+        )(self.update_playlist)
+
     async def _get_client(self, user_id: int, session: AsyncSession) -> SpotifyClient:
         """Create a SpotifyClient with token management for the given user."""
         settings = get_settings()
@@ -53,6 +112,21 @@ class PlaylistToolHandlers:
             return await token_mgr.refresh_access_token(user_id, session)
 
         return SpotifyClient(access_token, on_token_expired=_on_token_expired)
+
+    async def _check_write_scopes(self, user_id: int, session: AsyncSession) -> str | None:
+        """Check that the user's token has playlist-modify scopes. Returns error message or None."""
+        result = await session.execute(select(SpotifyToken.scope).where(SpotifyToken.user_id == user_id))
+        scope_str = result.scalar_one_or_none()
+        if scope_str is None:
+            return "No token found for this user. Please authorize via /auth/login."
+        granted = set(scope_str.split())
+        missing = _PLAYLIST_WRITE_SCOPES - granted
+        if missing:
+            return (
+                f"Missing required scopes: {', '.join(sorted(missing))}. "
+                "Please re-authorize via /auth/login to grant playlist write permissions."
+            )
+        return None
 
     async def list_playlists(self, args: dict[str, Any], session: AsyncSession) -> Any:
         client = await self._get_client(args["user_id"], session)
@@ -95,6 +169,70 @@ class PlaylistToolHandlers:
             "snapshot_id": pl.snapshot_id,
             "external_urls": pl.external_urls,
         }
+
+    async def create_playlist(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        scope_error = await self._check_write_scopes(args["user_id"], session)
+        if scope_error:
+            raise ValueError(scope_error)
+        client = await self._get_client(args["user_id"], session)
+        pl = await client.create_playlist(
+            name=args["name"],
+            description=args.get("description", ""),
+            public=args.get("public", True),
+        )
+        return {
+            "id": pl.id,
+            "name": pl.name,
+            "description": pl.description,
+            "public": pl.public,
+            "external_urls": pl.external_urls,
+        }
+
+    async def add_tracks(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        scope_error = await self._check_write_scopes(args["user_id"], session)
+        if scope_error:
+            raise ValueError(scope_error)
+        track_ids: list[str] = args["track_ids"]
+        if not track_ids:
+            raise ValueError("track_ids must not be empty.")
+        if len(track_ids) > 100:
+            raise ValueError("Maximum 100 tracks per call.")
+        uris = [f"spotify:track:{tid}" for tid in track_ids]
+        client = await self._get_client(args["user_id"], session)
+        result = await client.add_tracks_to_playlist(args["playlist_id"], uris)
+        return {"snapshot_id": result.snapshot_id, "tracks_added": len(track_ids)}
+
+    async def remove_tracks(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        scope_error = await self._check_write_scopes(args["user_id"], session)
+        if scope_error:
+            raise ValueError(scope_error)
+        track_ids: list[str] = args["track_ids"]
+        if not track_ids:
+            raise ValueError("track_ids must not be empty.")
+        if len(track_ids) > 100:
+            raise ValueError("Maximum 100 tracks per call.")
+        uris = [f"spotify:track:{tid}" for tid in track_ids]
+        client = await self._get_client(args["user_id"], session)
+        result = await client.remove_tracks_from_playlist(args["playlist_id"], uris)
+        return {"snapshot_id": result.snapshot_id, "tracks_removed": len(track_ids)}
+
+    async def update_playlist(self, args: dict[str, Any], session: AsyncSession) -> Any:
+        scope_error = await self._check_write_scopes(args["user_id"], session)
+        if scope_error:
+            raise ValueError(scope_error)
+        name = args.get("name")
+        description = args.get("description")
+        public = args.get("public")
+        if name is None and description is None and public is None:
+            raise ValueError("At least one of name, description, or public must be provided.")
+        client = await self._get_client(args["user_id"], session)
+        await client.update_playlist_details(
+            args["playlist_id"],
+            name=name,
+            description=description,
+            public=public,
+        )
+        return {"updated": True, "playlist_id": args["playlist_id"]}
 
 
 _instance = PlaylistToolHandlers()

--- a/services/api/tests/test_mcp/test_router.py
+++ b/services/api/tests/test_mcp/test_router.py
@@ -99,7 +99,7 @@ def test_list_tools(client: TestClient) -> None:
     assert resp.status_code == 200
     tools = resp.json()
     assert isinstance(tools, list)
-    assert len(tools) >= 17  # 6 history + 7 spotify + 4 ops
+    assert len(tools) >= 21  # 6 history + 11 spotify + 4 ops
     names = {t["name"] for t in tools}
     assert "history.taste_summary" in names
     assert "ops.sync_status" in names

--- a/services/frontend/tests/test_routes.py
+++ b/services/frontend/tests/test_routes.py
@@ -23,8 +23,9 @@ def test_dashboard_page(client: TestClient, mock_api: AsyncMock) -> None:
     assert response.status_code == 200
     assert "Dashboard" in response.text
     mock_api.get_sync_status.assert_called_once()
-    mock_api.list_job_runs.assert_called_once_with(limit=5)
-    mock_api.list_import_jobs.assert_called_once_with(limit=5)
+    mock_api.list_job_runs.assert_any_call(limit=5)
+    mock_api.list_job_runs.assert_any_call(status="running", limit=10)
+    mock_api.list_import_jobs.assert_any_call(limit=5)
 
 
 def test_dashboard_sync_status_partial(client: TestClient, mock_api: AsyncMock) -> None:


### PR DESCRIPTION
## Summary
- Add 4 playlist write MCP tools: `spotify.create_playlist`, `spotify.add_tracks`, `spotify.remove_tracks`, `spotify.update_playlist`
- Scope validation: write tools check `SpotifyToken.scope` for `playlist-modify-public` and `playlist-modify-private` — returns clear "re-authorize via /auth/login" error if missing
- Track ID to URI conversion: handlers convert `track_ids` to `spotify:track:{id}` URIs, capped at 100 per call
- Update OAuth scopes to include `playlist-modify-public playlist-modify-private`
- Improve MCP router error handling: `ValueError` messages are now passed through to responses (user-facing tool errors), while other exceptions remain generic
- Fix `test_dashboard_page` assertion that was failing in CI (dashboard now calls `list_job_runs` twice)
- Update ChatGPT OpenAPI schemas (JSON + YAML) with 4 new tool names and params (`name`, `description`, `public`, `track_ids`)
- Update GPT setup docs and CLAUDE.md with new tool listings

This is **Phase C** (final) of the playlist & track info plan. Phase A (client + models, PR #16) and Phase B (read tools, PR #17) are merged.

## Test plan
- [x] 16 playlist tool tests (6 read + 10 write): scope validation, empty list, >100 cap, no-token, create/add/remove/update happy paths
- [x] Full API test suite passes (203 tests)
- [x] Frontend test suite passes (40 tests, including fixed `test_dashboard_page`)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean (85 source files)
- [ ] Manual: deploy, re-authorize user via `/auth/login`, test full flow in ChatGPT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Four new Spotify playlist management tools now available: create playlists, add tracks (max 100), remove tracks (max 100), and update playlist metadata.
  * Enhanced authorization handling for playlist modification operations.

* **Documentation**
  * Updated API documentation to include new playlist management endpoints.

* **Tests**
  * Added comprehensive test coverage for new playlist functionality and authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->