### PR TITLE
fix: resolve deploy failure from .git/objects permission mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,8 @@ jobs:
             cd /opt/spotify-mcp
 
             echo "=== Fixing repo ownership ==="
-            sudo chown -R deploy:deploy /opt/spotify-mcp/.git
+            sudo -n chown -R deploy:deploy /opt/spotify-mcp/.git \
+              || { echo "ERROR: sudo requires a password for deploy"; exit 1; }
 
             echo "=== Deploying ref: $DEPLOY_REF ==="
             git fetch origin "$DEPLOY_REF"


### PR DESCRIPTION
## Summary

- Fix the deployment failure caused by `.git/objects` permission mismatch on the DigitalOcean droplet
- The `deploy` user couldn't write to `.git/objects` because some files were owned by `root` (likely from Docker operations)
- Added `sudo chown -R deploy:deploy /opt/spotify-mcp/.git` before `git fetch` to fix ownership
- Removed deprecated `script_stop` input from `appleboy/ssh-action@v1` (was generating a warning; `set -euo pipefail` already handles script stopping on errors)

## Test plan

- [ ] Merge PR and verify the GitHub Actions deployment succeeds
- [ ] Verify the `chown` step runs without error in the deploy log
- [ ] Verify the API and frontend health checks pass after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment process to avoid an unintended stop during remote execution.
  * Added a pre-deploy ownership fix to ensure correct file permissions for releases, with a non-interactive guard to prevent password prompts during automated deploys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->