### PR TITLE
fix: handle Spotify API playlist format change (items/item replaces tracks/track)

### DIFF
--- a/services/api/src/app/mcp/tools/playlist_tools.py
+++ b/services/api/src/app/mcp/tools/playlist_tools.py
@@ -158,7 +158,7 @@ class PlaylistToolHandlers:
                             "added_at": item.added_at,
                         }
                     )
-        result = {
+        return {
             "id": pl.id,
             "name": pl.name,
             "description": pl.description,
@@ -169,35 +169,6 @@ class PlaylistToolHandlers:
             "snapshot_id": pl.snapshot_id,
             "external_urls": pl.external_urls,
         }
-        # --- TEMPORARY DEBUG: raw Spotify response info ---
-        try:
-            from shared.spotify.constants import PLAYLIST_URL
-
-            # Raw request WITHOUT market
-            raw_resp = await client._request("GET", f"{PLAYLIST_URL}/{args['playlist_id']}")  # noqa: SLF001
-            raw_json = raw_resp.json()
-            raw_tracks = raw_json.get("tracks", "_MISSING_")
-            # Raw request WITH market
-            raw_resp2 = await client._request(  # noqa: SLF001
-                "GET", f"{PLAYLIST_URL}/{args['playlist_id']}", params={"market": "from_token"}
-            )
-            raw_json2 = raw_resp2.json()
-            raw_tracks2 = raw_json2.get("tracks", "_MISSING_")
-            debug: dict[str, Any] = {
-                "raw_top_keys": sorted(raw_json.keys()),
-                "raw_has_tracks_key": "tracks" in raw_json,
-                "raw_tracks_keys": list(raw_tracks.keys()) if isinstance(raw_tracks, dict) else str(raw_tracks)[:200],
-                "with_market_tracks_total": raw_tracks2.get("total") if isinstance(raw_tracks2, dict) else None,
-                "with_market_items_count": len(raw_tracks2.get("items", [])) if isinstance(raw_tracks2, dict) else None,
-                "with_market_tracks_keys": list(raw_tracks2.keys())
-                if isinstance(raw_tracks2, dict)
-                else str(raw_tracks2)[:200],
-            }
-            result["_debug"] = debug
-        except Exception:
-            pass
-        # --- END TEMPORARY DEBUG ---
-        return result
 
     async def create_playlist(self, args: dict[str, Any], session: AsyncSession) -> Any:
         scope_error = await self._check_write_scopes(args["user_id"], session)


### PR DESCRIPTION
## Summary

- Spotify's Web API renamed `tracks` → `items` at the playlist response level and `track` → `item` within playlist track objects (2025 API change)
- This caused `spotify.get_playlist` and `spotify.list_playlists` to return empty tracks for all playlists
- Added `model_validator(mode="before")` normalizers to `SpotifyPlaylist`, `SpotifyPlaylistTrackItem`, and `SpotifyPlaylistSimplified` to handle both old and new field names
- Fixed `SpotifyPlaylistSimplified.tracks` type from `dict[str, int]` to `dict[str, Any]` (Spotify returns `href` as a string)

## Test plan

- [x] All 244 tests pass (204 API + 40 frontend)
- [x] Added `test_get_playlist_new_api_format` covering the new `items`/`item` field names
- [x] Updated `test_get_user_playlists` to verify `dict[str, Any]` type fix
- [x] Lint and typecheck pass
- [ ] Deploy to production and verify `spotify.get_playlist` returns tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Spotify playlist data compatibility to handle updated API format variations.

* **Tests**
  * Added test coverage for new Spotify playlist API format parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->