### PR TITLE
feat: paginate playlist tracks for complete listing

### DIFF
--- a/services/api/src/app/mcp/tools/playlist_tools.py
+++ b/services/api/src/app/mcp/tools/playlist_tools.py
@@ -182,19 +182,19 @@ class PlaylistToolHandlers:
                 logger.debug("Playlist cache hit for %s (snapshot matched)", playlist_id)
                 return cached_data
 
-        # Cache miss or snapshot changed — build result from API response
+        # Cache miss or snapshot changed — fetch all tracks via pagination
+        all_track_items = await client.get_playlist_all_tracks(playlist_id)
         tracks = []
-        if pl.tracks:
-            for item in pl.tracks.items:
-                if item.track:
-                    tracks.append(
-                        {
-                            "id": item.track.id,
-                            "name": item.track.name,
-                            "artists": [{"id": a.id, "name": a.name} for a in item.track.artists],
-                            "added_at": item.added_at,
-                        }
-                    )
+        for item in all_track_items:
+            if item.track:
+                tracks.append(
+                    {
+                        "id": item.track.id,
+                        "name": item.track.name,
+                        "artists": [{"id": a.id, "name": a.name} for a in item.track.artists],
+                        "added_at": item.added_at,
+                    }
+                )
         result = {
             "id": pl.id,
             "name": pl.name,


### PR DESCRIPTION
## Summary
- Add `get_playlist_all_tracks()` to `SpotifyClient` that follows Spotify pagination `next` URLs to fetch all tracks (up to 10,000 cap)
- Update `spotify.get_playlist` MCP tool to use paginated fetch instead of relying on the first page (~100 tracks)
- Previously, large playlists were silently truncated — ChatGPT would see `tracks_total: 500` but only get 100 track objects

## Test plan
- [x] 3 new client-level tests: single page, multi-page pagination, max_tracks cap
- [x] Updated existing playlist tool test + new large playlist test (150 tracks across pages)
- [x] All 305 API tests pass
- [x] All 31 collector tests pass
- [x] ruff lint + format clean
- [x] mypy passes (93 source files)

## GPT changes
No changes needed to the Custom GPT. The `spotify.get_playlist` tool signature and response format are unchanged — it just returns complete data now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced playlist track retrieval with pagination support to reliably fetch all tracks from large playlists with built-in safety limits.

* **Tests**
  * Added comprehensive test coverage for single-page, multi-page, and large paginated playlist scenarios to ensure robust pagination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->