### PR TITLE
fix: force-recreate Caddy to fix TLS certificate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,10 +133,13 @@ jobs:
               exit 1
             fi
 
-            echo "=== Restarting Caddy to apply config ==="
-            docker compose --env-file .env.prod -f docker-compose.prod.yml restart caddy
-            echo "Waiting for Caddy to start..."
-            sleep 5
+            echo "=== Recreating Caddy to apply config + env vars ==="
+            docker compose --env-file .env.prod -f docker-compose.prod.yml up -d --force-recreate --no-deps caddy
+            echo "Waiting for Caddy to obtain TLS certificate..."
+            sleep 10
+
+            echo "=== Caddy logs (last 20 lines) ==="
+            docker compose --env-file .env.prod -f docker-compose.prod.yml logs --tail=20 caddy
 
             echo "=== Waiting for Explorer health ==="
             for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary

- Caddy was serving a self-signed `CN=localhost` certificate instead of a valid Let's Encrypt cert for `music.praxiscode.dev`
- Root cause: `docker compose restart caddy` only stops/starts the container without updating environment variables — the `DOMAIN` env var wasn't reaching the container
- Changed to `docker compose up -d --force-recreate --no-deps caddy` so the container is recreated with the latest env vars from `.env.prod` on every deploy
- Added Caddy log output (last 20 lines) after recreation for debugging visibility
- Increased post-restart wait from 5s to 10s for ACME certificate provisioning

## Test plan

- [ ] Deploy this branch and verify `music.praxiscode.dev` serves a valid Let's Encrypt certificate
- [ ] Verify all services remain healthy after Caddy recreation
- [ ] Check Caddy logs in deploy output for successful TLS provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process with enhanced service recreation and certificate provisioning reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->