### PR TITLE
fix: update release.yml regex to handle type-annotated __version__

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           import re
           with open('services/shared/src/shared/version.py') as f:
               content = f.read()
-          m = re.search(r'''__version__\s*=\s*['\"]([^'\"]+)['\"]''', content)
+          m = re.search(r'''__version__(?:\s*:\s*\w+)?\s*=\s*['\"]([^'\"]+)['\"]''', content)
           print(m.group(1))
           ")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The CodeRabbit fix in PR #44 added a `str` type annotation to `__version__`, changing it from `__version__ = "0.2.0"` to `__version__: str = "0.2.0"`
- The release workflow regex `__version__\s*=\s*['"]...` didn't account for the optional `: str` annotation → failed with `AttributeError: 'NoneType' object has no attribute 'group'`
- Updated regex to `__version__(?:\s*:\s*\w+)?\s*=\s*['"]([^'"]+)['"]` — handles both annotated and unannotated forms

## Test plan
- [ ] Merge to main and verify release workflow creates `v0.2.0` tag + pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version detection in the release process to handle additional code formatting variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->