### PR TITLE
feat: resolve local track IDs to real Spotify IDs

### DIFF
--- a/services/api/alembic/versions/013_track_resolution_attempted_at.py
+++ b/services/api/alembic/versions/013_track_resolution_attempted_at.py
@@ -1,0 +1,28 @@
+"""Add resolution_attempted_at to tracks for local track resolution
+
+Revision ID: 013_resolution_attempted_at
+Revises: 012_playlist_freshness
+Create Date: 2026-04-03
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "013_resolution_attempted_at"
+down_revision = "012_playlist_freshness"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tracks",
+        sa.Column("resolution_attempted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tracks", "resolution_attempted_at")

--- a/services/collector/src/collector/resolve.py
+++ b/services/collector/src/collector/resolve.py
@@ -1,0 +1,203 @@
+"""Local track resolution — resolve local:<sha1> IDs to real Spotify track IDs."""
+
+import logging
+import unicodedata
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from collector.settings import CollectorSettings
+from collector.tokens import CollectorTokenManager
+from shared.db.enums import JobStatus, JobType, TrackSource
+from shared.db.models.music import Track
+from shared.db.models.operations import JobRun
+from shared.db.models.user import SpotifyToken
+from shared.spotify.client import SpotifyClient
+from shared.spotify.models import SpotifyTrack
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize(name: str) -> str:
+    """Normalize a name for comparison: lowercase, strip, collapse whitespace, NFKD."""
+    text = unicodedata.normalize("NFKD", name)
+    return " ".join(text.lower().split())
+
+
+def _is_match(local_track: str, local_artist: str, candidate: SpotifyTrack) -> bool:
+    """Strict match: both track name and primary artist must match after normalization."""
+    if _normalize(candidate.name) != _normalize(local_track):
+        return False
+    if not candidate.artists:
+        return False
+    return _normalize(candidate.artists[0].name) == _normalize(local_artist)
+
+
+class LocalTrackResolutionService:
+    """Resolves local:<sha1> track IDs to real Spotify track IDs via search."""
+
+    def __init__(self, settings: CollectorSettings) -> None:
+        self._settings = settings
+        self._token_manager = CollectorTokenManager(settings)
+
+    async def resolve(self, session: AsyncSession) -> int:
+        """Resolve unresolved local tracks. Returns count of resolved tracks."""
+        if not self._settings.RESOLVE_LOCAL_TRACKS_ENABLED:
+            return 0
+
+        cooldown_cutoff = datetime.now(UTC) - timedelta(days=self._settings.RESOLVE_COOLDOWN_DAYS)
+
+        # Find tracks that need resolution:
+        # - Have a local_track_id (from ZIP import)
+        # - Have no spotify_track_id (not yet resolved)
+        # - Haven't been attempted recently (cooldown)
+        tracks_to_resolve = await self._find_unresolved_tracks(session, cooldown_cutoff)
+
+        if not tracks_to_resolve:
+            logger.debug("No local tracks need resolution")
+            return 0
+
+        logger.info("Found %d local tracks to resolve", len(tracks_to_resolve))
+
+        # Need a user token for Spotify API calls
+        user_id = await self._get_any_active_user(session)
+        if user_id is None:
+            logger.warning("No active users with Spotify tokens, skipping resolution")
+            return 0
+
+        # Record job start
+        job_run = JobRun(
+            user_id=user_id,
+            job_type=JobType.RESOLVE_LOCAL,
+            started_at=datetime.now(UTC),
+            status=JobStatus.RUNNING,
+        )
+        session.add(job_run)
+        await session.flush()
+
+        total_resolved = 0
+        total_attempted = 0
+
+        try:
+            client = await self._create_spotify_client(user_id, session)
+
+            for i in range(0, len(tracks_to_resolve), self._settings.RESOLVE_BATCH_SIZE):
+                batch = tracks_to_resolve[i : i + self._settings.RESOLVE_BATCH_SIZE]
+                resolved, attempted = await self._resolve_batch(batch, client, session)
+                total_resolved += resolved
+                total_attempted += attempted
+                await session.flush()
+
+            job_run.completed_at = datetime.now(UTC)
+            job_run.status = JobStatus.SUCCESS
+            job_run.records_fetched = total_attempted
+            job_run.records_inserted = total_resolved
+            await session.commit()
+        except Exception:
+            logger.exception("Error during local track resolution")
+            await session.rollback()
+            job_run.completed_at = datetime.now(UTC)
+            job_run.status = JobStatus.ERROR
+            job_run.error_message = "Resolution failed — see logs"
+            session.add(job_run)
+            await session.commit()
+            raise
+
+        logger.info("Resolved %d/%d local tracks", total_resolved, total_attempted)
+        return total_resolved
+
+    async def _find_unresolved_tracks(self, session: AsyncSession, cooldown_cutoff: datetime) -> list[Track]:
+        """Find local tracks eligible for resolution."""
+        result = await session.execute(
+            select(Track)
+            .options(selectinload(Track.artists))
+            .where(
+                Track.local_track_id.isnot(None),
+                Track.spotify_track_id.is_(None),
+                Track.source == TrackSource.IMPORT_ZIP,
+                # Either never attempted or attempted before cooldown
+                (Track.resolution_attempted_at.is_(None)) | (Track.resolution_attempted_at < cooldown_cutoff),
+            )
+            .limit(self._settings.RESOLVE_MAX_PER_CYCLE)
+        )
+        return list(result.scalars().all())
+
+    async def _resolve_batch(
+        self,
+        tracks: list[Track],
+        client: SpotifyClient,
+        session: AsyncSession,
+    ) -> tuple[int, int]:
+        """Resolve a batch of tracks. Returns (resolved_count, attempted_count)."""
+        resolved = 0
+
+        for track in tracks:
+            # Get the primary artist name
+            artist_name = self._get_primary_artist_name(track)
+            if not artist_name:
+                track.resolution_attempted_at = datetime.now(UTC)
+                continue
+
+            try:
+                query = f"track:{track.name} artist:{artist_name}"
+                search_result = await client.search(query, search_type="track", limit=5)
+
+                if search_result.tracks and search_result.tracks.items:
+                    match = self._find_best_match(track.name, artist_name, search_result.tracks.items)
+                    if match:
+                        track.spotify_track_id = match.id
+                        track.source = TrackSource.RESOLVED
+                        if match.duration_ms and not track.duration_ms:
+                            track.duration_ms = match.duration_ms
+                        if match.album and match.album.name and not track.album_name:
+                            track.album_name = match.album.name
+                        if match.album and match.album.id and not track.album_spotify_id:
+                            track.album_spotify_id = match.album.id
+                        resolved += 1
+                        logger.debug(
+                            "Resolved '%s' by '%s' → %s",
+                            track.name,
+                            artist_name,
+                            match.id,
+                        )
+
+                track.resolution_attempted_at = datetime.now(UTC)
+
+            except Exception:
+                logger.warning("Search failed for '%s' by '%s'", track.name, artist_name, exc_info=True)
+                track.resolution_attempted_at = datetime.now(UTC)
+
+        return resolved, len(tracks)
+
+    @staticmethod
+    def _get_primary_artist_name(track: Track) -> str | None:
+        """Get the name of the first artist for a track."""
+        if not track.artists:
+            return None
+        # Artists are ordered by TrackArtist.position; relationship loads in PK order
+        return track.artists[0].name
+
+    @staticmethod
+    def _find_best_match(track_name: str, artist_name: str, candidates: list[SpotifyTrack]) -> SpotifyTrack | None:
+        """Find the first candidate that strictly matches track + artist name."""
+        for candidate in candidates:
+            if candidate.id and _is_match(track_name, artist_name, candidate):
+                return candidate
+        return None
+
+    async def _create_spotify_client(self, user_id: int, session: AsyncSession) -> SpotifyClient:
+        """Create a SpotifyClient for a user."""
+        access_token = await self._token_manager.get_valid_token(user_id, session)
+
+        async def _on_expired() -> str:
+            return await self._token_manager.refresh_access_token(user_id, session)
+
+        return SpotifyClient(access_token, on_token_expired=_on_expired)
+
+    @staticmethod
+    async def _get_any_active_user(session: AsyncSession) -> int | None:
+        """Get any user ID that has an active Spotify token."""
+        result = await session.execute(select(SpotifyToken.user_id).limit(1))
+        return result.scalar_one_or_none()

--- a/services/collector/src/collector/resolve.py
+++ b/services/collector/src/collector/resolve.py
@@ -176,7 +176,6 @@ class LocalTrackResolutionService:
         """Get the name of the first artist for a track."""
         if not track.artists:
             return None
-        # Artists are ordered by TrackArtist.position; relationship loads in PK order
         return track.artists[0].name
 
     @staticmethod
@@ -198,6 +197,10 @@ class LocalTrackResolutionService:
 
     @staticmethod
     async def _get_any_active_user(session: AsyncSession) -> int | None:
-        """Get any user ID that has an active Spotify token."""
+        """Get any user ID that has an active Spotify token.
+
+        Search results are account-agnostic (free/premium, region don't affect search),
+        so any valid token suffices.
+        """
         result = await session.execute(select(SpotifyToken.user_id).limit(1))
         return result.scalar_one_or_none()

--- a/services/collector/src/collector/resolve.py
+++ b/services/collector/src/collector/resolve.py
@@ -97,11 +97,17 @@ class LocalTrackResolutionService:
             await session.commit()
         except Exception:
             logger.exception("Error during local track resolution")
+            started_at = job_run.started_at
             await session.rollback()
-            job_run.completed_at = datetime.now(UTC)
-            job_run.status = JobStatus.ERROR
-            job_run.error_message = "Resolution failed — see logs"
-            session.add(job_run)
+            error_job = JobRun(
+                user_id=user_id,
+                job_type=JobType.RESOLVE_LOCAL,
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                status=JobStatus.ERROR,
+                error_message="Resolution failed — see logs",
+            )
+            session.add(error_job)
             await session.commit()
             raise
 
@@ -141,7 +147,9 @@ class LocalTrackResolutionService:
                 continue
 
             try:
-                query = f"track:{track.name} artist:{artist_name}"
+                escaped_track = track.name.replace('"', '\\"')
+                escaped_artist = artist_name.replace('"', '\\"')
+                query = f'track:"{escaped_track}" artist:"{escaped_artist}"'
                 search_result = await client.search(query, search_type="track", limit=5)
 
                 if search_result.tracks and search_result.tracks.items:

--- a/services/collector/src/collector/runloop.py
+++ b/services/collector/src/collector/runloop.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from collector.enrichment import AudioFeaturesEnrichmentService
 from collector.initial_sync import InitialSyncService
 from collector.polling import PollingService
+from collector.resolve import LocalTrackResolutionService
 from collector.settings import CollectorSettings
 from collector.zip_import import ZipImportService
 from shared.db.enums import SyncStatus
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class CollectorRunLoop:
-    """Priority-based collector: ZIP imports -> initial sync -> incremental polling -> enrichment."""
+    """Priority-based collector: ZIP imports -> initial sync -> polling -> enrichment -> resolution."""
 
     def __init__(self, settings: CollectorSettings, db_manager: DatabaseManager) -> None:
         self._settings = settings
@@ -30,6 +31,7 @@ class CollectorRunLoop:
         self._initial_sync_service = InitialSyncService(settings)
         self._zip_import_service = ZipImportService(settings)
         self._enrichment_service = AudioFeaturesEnrichmentService(settings)
+        self._resolution_service = LocalTrackResolutionService(settings)
         self._user_semaphore = asyncio.Semaphore(self._settings.INITIAL_SYNC_CONCURRENCY)
 
     async def run(self, shutdown_event: asyncio.Event) -> None:
@@ -83,7 +85,7 @@ class CollectorRunLoop:
             if isinstance(result, Exception):
                 logger.error("Error processing user %d: %s", user_id, result)
 
-        # Phase 4: Audio features enrichment (lowest priority)
+        # Phase 4: Audio features enrichment
         try:
             async with self._db_manager.session() as session:
                 enriched = await self._enrichment_service.enrich(session)
@@ -91,6 +93,15 @@ class CollectorRunLoop:
                     logger.info("Enriched %d tracks with audio features", enriched)
         except Exception:
             logger.exception("Error during audio features enrichment phase")
+
+        # Phase 5: Local track resolution (lowest priority)
+        try:
+            async with self._db_manager.session() as session:
+                resolved = await self._resolution_service.resolve(session)
+                if resolved:
+                    logger.info("Resolved %d local tracks to Spotify IDs", resolved)
+        except Exception:
+            logger.exception("Error during local track resolution phase")
 
         logger.info("Collector cycle complete")
 

--- a/services/collector/src/collector/settings.py
+++ b/services/collector/src/collector/settings.py
@@ -36,6 +36,12 @@ class CollectorSettings(BaseSettings):
     ENRICH_BATCH_SIZE: int = 100
     ENRICH_MAX_PER_CYCLE: int = 500
 
+    # Local track resolution
+    RESOLVE_LOCAL_TRACKS_ENABLED: bool = True
+    RESOLVE_BATCH_SIZE: int = 50
+    RESOLVE_MAX_PER_CYCLE: int = 200
+    RESOLVE_COOLDOWN_DAYS: int = 30
+
     # Valkey cache
     VALKEY_URL: str = ""
 

--- a/services/collector/tests/test_resolve.py
+++ b/services/collector/tests/test_resolve.py
@@ -1,0 +1,542 @@
+"""Tests for LocalTrackResolutionService."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from collector.resolve import LocalTrackResolutionService, _is_match, _normalize
+from collector.settings import CollectorSettings
+from shared.crypto import TokenEncryptor
+from shared.db.base import Base
+from shared.db.enums import JobStatus, JobType, TrackSource
+from shared.db.models.music import Artist, Track, TrackArtist
+from shared.db.models.operations import JobRun
+from shared.db.models.user import SpotifyToken, User
+from shared.spotify.models import (
+    SpotifyArtistSimplified,
+    SpotifySearchResponse,
+    SpotifySearchTracks,
+    SpotifyTrack,
+)
+
+TEST_FERNET_KEY = Fernet.generate_key().decode()
+
+
+def _test_settings(**overrides: object) -> CollectorSettings:
+    defaults: dict[str, object] = {
+        "SPOTIFY_CLIENT_ID": "test-id",
+        "SPOTIFY_CLIENT_SECRET": "test-secret",
+        "TOKEN_ENCRYPTION_KEY": TEST_FERNET_KEY,
+        "RESOLVE_LOCAL_TRACKS_ENABLED": True,
+        "RESOLVE_BATCH_SIZE": 10,
+        "RESOLVE_MAX_PER_CYCLE": 100,
+        "RESOLVE_COOLDOWN_DAYS": 30,
+    }
+    defaults.update(overrides)
+    return CollectorSettings(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+async def async_engine():  # type: ignore[no-untyped-def]
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def async_session(async_engine):  # type: ignore[no-untyped-def]
+    session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+
+async def _create_user_with_token(session: AsyncSession) -> User:
+    encryptor = TokenEncryptor(TEST_FERNET_KEY)
+    user = User(spotify_user_id="testuser", display_name="Test")
+    session.add(user)
+    await session.flush()
+    token = SpotifyToken(
+        user_id=user.id,
+        encrypted_refresh_token=encryptor.encrypt("refresh-token"),
+        access_token="valid-access-token",
+        token_expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    session.add(token)
+    await session.flush()
+    return user
+
+
+async def _create_local_track(
+    session: AsyncSession,
+    name: str,
+    artist_name: str,
+    local_id: str = "local:abc123",
+    *,
+    resolution_attempted_at: datetime | None = None,
+) -> Track:
+    """Create a local track with an artist association."""
+    track = Track(
+        local_track_id=local_id,
+        spotify_track_id=None,
+        name=name,
+        source=TrackSource.IMPORT_ZIP,
+        resolution_attempted_at=resolution_attempted_at,
+    )
+    session.add(track)
+    await session.flush()
+
+    artist = Artist(
+        local_artist_id=f"local:artist_{local_id}",
+        name=artist_name,
+        source=TrackSource.IMPORT_ZIP,
+    )
+    session.add(artist)
+    await session.flush()
+
+    ta = TrackArtist(track_id=track.id, artist_id=artist.id, position=0)
+    session.add(ta)
+    await session.flush()
+
+    return track
+
+
+def _make_search_response(*tracks: SpotifyTrack) -> SpotifySearchResponse:
+    """Build a SpotifySearchResponse with the given tracks."""
+    return SpotifySearchResponse(tracks=SpotifySearchTracks(items=list(tracks), total=len(tracks)))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for normalization and matching
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def test_lowercase(self) -> None:
+        assert _normalize("Hello World") == "hello world"
+
+    def test_strip_whitespace(self) -> None:
+        assert _normalize("  hello  world  ") == "hello world"
+
+    def test_unicode_normalization(self) -> None:
+        # NFKD normalizes e.g. composed characters
+        assert _normalize("café") == _normalize("café")
+
+    def test_empty_string(self) -> None:
+        assert _normalize("") == ""
+
+
+class TestIsMatch:
+    def test_exact_match(self) -> None:
+        candidate = SpotifyTrack(
+            id="abc",
+            name="Bohemian Rhapsody",
+            artists=[SpotifyArtistSimplified(id="a1", name="Queen")],
+        )
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is True
+
+    def test_case_insensitive_match(self) -> None:
+        candidate = SpotifyTrack(
+            id="abc",
+            name="bohemian rhapsody",
+            artists=[SpotifyArtistSimplified(id="a1", name="queen")],
+        )
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is True
+
+    def test_no_match_different_track(self) -> None:
+        candidate = SpotifyTrack(
+            id="abc",
+            name="We Will Rock You",
+            artists=[SpotifyArtistSimplified(id="a1", name="Queen")],
+        )
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is False
+
+    def test_no_match_different_artist(self) -> None:
+        candidate = SpotifyTrack(
+            id="abc",
+            name="Bohemian Rhapsody",
+            artists=[SpotifyArtistSimplified(id="a1", name="The Beatles")],
+        )
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is False
+
+    def test_no_match_empty_artists(self) -> None:
+        candidate = SpotifyTrack(id="abc", name="Bohemian Rhapsody", artists=[])
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is False
+
+    def test_whitespace_differences(self) -> None:
+        candidate = SpotifyTrack(
+            id="abc",
+            name="Bohemian  Rhapsody",
+            artists=[SpotifyArtistSimplified(id="a1", name="Queen")],
+        )
+        assert _is_match("Bohemian Rhapsody", "Queen", candidate) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for resolution service
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_happy_path(async_session: AsyncSession) -> None:
+    """Successful resolution updates track with Spotify ID and source."""
+    await _create_user_with_token(async_session)
+    track = await _create_local_track(async_session, "Bohemian Rhapsody", "Queen", "local:aaa")
+
+    settings = _test_settings()
+    service = LocalTrackResolutionService(settings)
+
+    search_response = _make_search_response(
+        SpotifyTrack(
+            id="6rqhFgbbKwnb9MLmUQDhG6",
+            name="Bohemian Rhapsody",
+            duration_ms=354000,
+            artists=[SpotifyArtistSimplified(id="1dfeR4HaWDbWqFHLkxsg1d", name="Queen")],
+        )
+    )
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=search_response)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 1
+
+    # Verify track updated
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.spotify_track_id == "6rqhFgbbKwnb9MLmUQDhG6"
+    assert updated.source == TrackSource.RESOLVED
+    assert updated.duration_ms == 354000
+    assert updated.resolution_attempted_at is not None
+
+    # Verify job run
+    result = await async_session.execute(select(JobRun).where(JobRun.job_type == JobType.RESOLVE_LOCAL))
+    job = result.scalar_one()
+    assert job.status == JobStatus.SUCCESS
+    assert job.records_inserted == 1
+    assert job.records_fetched == 1
+
+
+async def test_resolve_no_match(async_session: AsyncSession) -> None:
+    """When search returns no match, track keeps local ID but gets timestamp."""
+    await _create_user_with_token(async_session)
+    track = await _create_local_track(async_session, "Obscure Song", "Unknown Artist", "local:bbb")
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    # Search returns results but none match
+    search_response = _make_search_response(
+        SpotifyTrack(
+            id="xyz",
+            name="Different Song",
+            artists=[SpotifyArtistSimplified(id="a1", name="Different Artist")],
+        )
+    )
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=search_response)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 0
+
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.spotify_track_id is None
+    assert updated.source == TrackSource.IMPORT_ZIP
+    assert updated.resolution_attempted_at is not None
+
+
+async def test_resolve_empty_search_results(async_session: AsyncSession) -> None:
+    """When search returns empty results, track is marked as attempted."""
+    await _create_user_with_token(async_session)
+    track = await _create_local_track(async_session, "NoResults", "NoArtist", "local:ccc")
+
+    service = LocalTrackResolutionService(_test_settings())
+    empty_response = SpotifySearchResponse(tracks=SpotifySearchTracks(items=[], total=0))
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=empty_response)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 0
+
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.resolution_attempted_at is not None
+
+
+async def test_resolve_skips_recently_attempted(async_session: AsyncSession) -> None:
+    """Tracks attempted within cooldown period are skipped."""
+    await _create_user_with_token(async_session)
+    recent = datetime.now(UTC) - timedelta(days=1)
+    await _create_local_track(async_session, "Recent Track", "Artist", "local:ddd", resolution_attempted_at=recent)
+
+    service = LocalTrackResolutionService(_test_settings(RESOLVE_COOLDOWN_DAYS=30))
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 0
+    # Search should not have been called
+    mock_client.search.assert_not_called()
+
+
+async def test_resolve_retries_after_cooldown(async_session: AsyncSession) -> None:
+    """Tracks attempted beyond cooldown period are retried."""
+    await _create_user_with_token(async_session)
+    old = datetime.now(UTC) - timedelta(days=60)
+    track = await _create_local_track(
+        async_session, "Old Track", "Old Artist", "local:eee", resolution_attempted_at=old
+    )
+
+    service = LocalTrackResolutionService(_test_settings(RESOLVE_COOLDOWN_DAYS=30))
+
+    search_response = _make_search_response(
+        SpotifyTrack(
+            id="resolved123",
+            name="Old Track",
+            artists=[SpotifyArtistSimplified(id="a1", name="Old Artist")],
+        )
+    )
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=search_response)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 1
+
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.spotify_track_id == "resolved123"
+
+
+async def test_resolve_disabled(async_session: AsyncSession) -> None:
+    """When disabled, returns 0 immediately."""
+    service = LocalTrackResolutionService(_test_settings(RESOLVE_LOCAL_TRACKS_ENABLED=False))
+    resolved = await service.resolve(async_session)
+    assert resolved == 0
+
+
+async def test_resolve_no_active_users(async_session: AsyncSession) -> None:
+    """When no users have Spotify tokens, skip resolution."""
+    await _create_local_track(async_session, "Track", "Artist", "local:fff")
+
+    service = LocalTrackResolutionService(_test_settings())
+    resolved = await service.resolve(async_session)
+    assert resolved == 0
+
+
+async def test_resolve_skips_already_resolved_tracks(async_session: AsyncSession) -> None:
+    """Tracks that already have a spotify_track_id are not queried."""
+    await _create_user_with_token(async_session)
+
+    # Track with both local and spotify ID (already resolved)
+    track = Track(
+        local_track_id="local:ggg",
+        spotify_track_id="already_resolved",
+        name="Already Resolved",
+        source=TrackSource.RESOLVED,
+    )
+    async_session.add(track)
+    await async_session.flush()
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 0
+    mock_client.search.assert_not_called()
+
+
+async def test_resolve_skips_track_without_artist(async_session: AsyncSession) -> None:
+    """Tracks with no associated artist are marked attempted but not searched."""
+    await _create_user_with_token(async_session)
+
+    # Track with no artist association
+    track = Track(
+        local_track_id="local:hhh",
+        spotify_track_id=None,
+        name="Orphan Track",
+        source=TrackSource.IMPORT_ZIP,
+    )
+    async_session.add(track)
+    await async_session.flush()
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 0
+    mock_client.search.assert_not_called()
+
+    # But track should be marked as attempted
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.resolution_attempted_at is not None
+
+
+async def test_resolve_enriches_metadata(async_session: AsyncSession) -> None:
+    """Resolution fills in duration_ms, album_name, album_spotify_id when missing."""
+    await _create_user_with_token(async_session)
+    track = await _create_local_track(async_session, "Test Track", "Test Artist", "local:iii")
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    from shared.spotify.models import SpotifyAlbumSimplified
+
+    search_response = _make_search_response(
+        SpotifyTrack(
+            id="spotify123",
+            name="Test Track",
+            duration_ms=240000,
+            artists=[SpotifyArtistSimplified(id="a1", name="Test Artist")],
+            album=SpotifyAlbumSimplified(id="album123", name="Test Album"),
+        )
+    )
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=search_response)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 1
+
+    result = await async_session.execute(select(Track).where(Track.id == track.id))
+    updated = result.scalar_one()
+    assert updated.duration_ms == 240000
+    assert updated.album_name == "Test Album"
+    assert updated.album_spotify_id == "album123"
+
+
+async def test_resolve_multiple_tracks(async_session: AsyncSession) -> None:
+    """Multiple tracks resolved in one cycle."""
+    await _create_user_with_token(async_session)
+    await _create_local_track(async_session, "Track A", "Artist A", "local:j1")
+    await _create_local_track(async_session, "Track B", "Artist B", "local:j2")
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    responses = [
+        _make_search_response(
+            SpotifyTrack(
+                id="sp_a",
+                name="Track A",
+                artists=[SpotifyArtistSimplified(id="a1", name="Artist A")],
+            )
+        ),
+        _make_search_response(
+            SpotifyTrack(
+                id="sp_b",
+                name="Track B",
+                artists=[SpotifyArtistSimplified(id="a2", name="Artist B")],
+            )
+        ),
+    ]
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(side_effect=responses)
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 2
+
+    result = await async_session.execute(select(JobRun).where(JobRun.job_type == JobType.RESOLVE_LOCAL))
+    job = result.scalar_one()
+    assert job.records_inserted == 2
+    assert job.records_fetched == 2
+
+
+async def test_resolve_search_error_continues(async_session: AsyncSession) -> None:
+    """A search error for one track doesn't stop the batch; track is marked attempted."""
+    await _create_user_with_token(async_session)
+    track1 = await _create_local_track(async_session, "Good Track", "Good Artist", "local:k1")
+    track2 = await _create_local_track(async_session, "Bad Track", "Bad Artist", "local:k2")
+
+    service = LocalTrackResolutionService(_test_settings())
+
+    good_response = _make_search_response(
+        SpotifyTrack(
+            id="sp_good",
+            name="Good Track",
+            artists=[SpotifyArtistSimplified(id="a1", name="Good Artist")],
+        )
+    )
+
+    with (
+        patch.object(service._token_manager, "get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("collector.resolve.SpotifyClient") as mock_cls,
+    ):
+        mock_client = AsyncMock()
+        # First search succeeds, second fails
+        mock_client.search = AsyncMock(side_effect=[good_response, RuntimeError("API error")])
+        mock_cls.return_value = mock_client
+
+        resolved = await service.resolve(async_session)
+
+    assert resolved == 1
+
+    # Both tracks should be marked as attempted
+    result = await async_session.execute(select(Track).where(Track.id == track1.id))
+    assert result.scalar_one().resolution_attempted_at is not None
+    result = await async_session.execute(select(Track).where(Track.id == track2.id))
+    assert result.scalar_one().resolution_attempted_at is not None

--- a/services/shared/src/shared/db/enums.py
+++ b/services/shared/src/shared/db/enums.py
@@ -19,6 +19,7 @@ class JobType(enum.StrEnum):
     INITIAL_SYNC = "initial_sync"
     POLL = "poll"
     ENRICH = "enrich"
+    RESOLVE_LOCAL = "resolve_local"
 
 
 class JobStatus(enum.StrEnum):
@@ -53,6 +54,7 @@ class TrackSource(enum.StrEnum):
 
     SPOTIFY_API = "spotify_api"
     IMPORT_ZIP = "import_zip"
+    RESOLVED = "resolved"
 
 
 class PreferenceEventSource(enum.StrEnum):

--- a/services/shared/src/shared/db/models/music.py
+++ b/services/shared/src/shared/db/models/music.py
@@ -44,6 +44,7 @@ class Track(Base):
         nullable=False,
         default=TrackSource.SPOTIFY_API,
     )
+    resolution_attempted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=utc_now)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=utc_now, onupdate=utc_now

--- a/services/shared/src/shared/db/models/music.py
+++ b/services/shared/src/shared/db/models/music.py
@@ -51,7 +51,9 @@ class Track(Base):
     )
 
     # Relationships
-    artists: Mapped[list[Artist]] = relationship("Artist", secondary="track_artists", back_populates="tracks")
+    artists: Mapped[list[Artist]] = relationship(
+        "Artist", secondary="track_artists", back_populates="tracks", order_by="TrackArtist.position"
+    )
     plays: Mapped[list[Play]] = relationship("Play", back_populates="track")
     audio_features: Mapped[AudioFeatures | None] = relationship("AudioFeatures", back_populates="track", uselist=False)
 


### PR DESCRIPTION
## Summary
- Add `LocalTrackResolutionService` to the collector — resolves `local:<sha1>` track IDs (from ZIP imports) to real Spotify IDs via search API
- Strict NFKD-normalized, case-insensitive matching on both track name and primary artist to avoid false positives
- Cooldown mechanism (`RESOLVE_COOLDOWN_DAYS`, default 30) prevents re-trying failed matches
- Runs as Phase 5 in the collector run loop (lowest priority, after enrichment)
- New migration `013` adds `resolution_attempted_at` column to `tracks` table
- New enum values: `JobType.RESOLVE_LOCAL`, `TrackSource.RESOLVED`

Closes #47

## Config
| Variable | Default | Description |
|---|---|---|
| `RESOLVE_LOCAL_TRACKS_ENABLED` | `true` | Enable/disable resolution |
| `RESOLVE_BATCH_SIZE` | `50` | Tracks per batch |
| `RESOLVE_MAX_PER_CYCLE` | `200` | Max tracks per collector cycle |
| `RESOLVE_COOLDOWN_DAYS` | `30` | Days before re-trying a failed match |

## Test plan
- [x] 22 new tests (unit + integration) — normalization, matching, happy path, no match, cooldown, disabled, error resilience
- [x] Full collector suite: 53 passed
- [x] Full API suite: 618 passed
- [x] Ruff lint + format clean
- [x] mypy clean
- [x] Docker integration: all containers healthy, migration applied successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic resolution of imported local tracks to Spotify IDs with batched processing, cooldowns, per-cycle limits, and post-enrichment run phase
  * Resolution fills missing metadata (duration, album name/ID) when available; per-track attempt timestamps recorded

* **Database**
  * Added nullable timestamp on tracks for resolution attempts
  * Added job/track-source enum values for resolution jobs and resolved tracks

* **Configuration**
  * New settings to enable resolution and control batch size, max per cycle, and cooldown

* **Tests**
  * Comprehensive unit and integration tests for matching, normalization, batching, retries, and metrics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->